### PR TITLE
#197 if event began already and has only offline payment method then …

### DIFF
--- a/src/main/java/alfio/controller/EventController.java
+++ b/src/main/java/alfio/controller/EventController.java
@@ -32,6 +32,7 @@ import alfio.model.modification.support.LocationDescriptor;
 import alfio.model.result.ValidationResult;
 import alfio.model.system.Configuration;
 import alfio.model.system.ConfigurationKeys;
+import alfio.model.transaction.PaymentProxy;
 import alfio.repository.*;
 import alfio.repository.user.OrganizationRepository;
 import alfio.util.ErrorsCode;
@@ -220,6 +221,7 @@ public class EventController {
             List<SaleableTicketCategory> validCategories = ticketCategories.stream().filter(tc -> !tc.getExpired()).collect(Collectors.toList());
             List<SaleableAdditionalService> additionalServices = additionalServiceRepository.loadAllForEvent(event.getId()).stream().map((as) -> getSaleableAdditionalService(event, locale, as, promoCodeDiscount.orElse(null))).collect(Collectors.toList());
             Predicate<SaleableTicketCategory> waitingQueueTargetCategory = tc -> !tc.getExpired() && !tc.isBounded();
+            boolean inValidOfflinePayment = event.getAllowedPaymentProxies().size() == 1 && event.getAllowedPaymentProxies().contains(PaymentProxy.OFFLINE) && !TicketReservationManager.hasValidOfflinePaymentWaitingPeriod(event, configurationManager);
             model.addAttribute("event", eventDescriptor)//
                 .addAttribute("organization", organizationRepository.getById(event.getOrganizationId()))
                 .addAttribute("ticketCategories", validCategories)//
@@ -240,8 +242,10 @@ public class EventController {
                 .addAttribute("showAdditionalServices", !additionalServices.isEmpty())
                 .addAttribute("enabledAdditionalServices", additionalServices.stream().filter(SaleableAdditionalService::isNotExpired).collect(Collectors.toList()))
                 .addAttribute("disabledAdditionalServices", additionalServices.stream().filter(SaleableAdditionalService::isExpired).collect(Collectors.toList()))
-                .addAttribute("forwardButtonDisabled", ticketCategories.stream().noneMatch(SaleableTicketCategory::getSaleable))
-                .addAttribute("useFirstAndLastName", event.mustUseFirstAndLastName());
+                .addAttribute("forwardButtonDisabled", (ticketCategories.stream().noneMatch(SaleableTicketCategory::getSaleable)) || inValidOfflinePayment)
+                .addAttribute("useFirstAndLastName", event.mustUseFirstAndLastName())
+                .addAttribute("validPaymentMethodAvailable", !inValidOfflinePayment);
+
             model.asMap().putIfAbsent("hasErrors", false);//
             return "/event/show-event";
         }).orElse(REDIRECT + "/");

--- a/src/main/java/alfio/controller/ReservationController.java
+++ b/src/main/java/alfio/controller/ReservationController.java
@@ -169,7 +169,7 @@ public class ReservationController {
                     OrderSummary orderSummary = ticketReservationManager.orderSummaryForReservationId(reservationId, event, locale);
                     List<PaymentProxy> activePaymentMethods = paymentManager.getPaymentMethods(event.getOrganizationId())
                         .stream()
-                        .filter(p -> p.isActive() && event.getAllowedPaymentProxies().contains(p.getPaymentProxy()) && !p.getPaymentProxy().equals(PaymentProxy.OFFLINE) || (p.getPaymentProxy().equals(PaymentProxy.OFFLINE) && p.isActive() && event.getAllowedPaymentProxies().contains(p.getPaymentProxy()) && TicketReservationManager.hasValidOfflinePaymentWaitingPeriod(event, configurationManager)))
+                        .filter(p -> TicketReservationManager.isValidPaymentMethod(p, event, configurationManager))
                         .map(PaymentManager.PaymentMethod::getPaymentProxy)
                         .collect(toList());
                     model.addAttribute("multiplePaymentMethods" , activePaymentMethods.size() > 1 );

--- a/src/main/java/alfio/manager/TicketReservationManager.java
+++ b/src/main/java/alfio/manager/TicketReservationManager.java
@@ -501,6 +501,19 @@ public class TicketReservationManager {
         }
     }
 
+
+    /**
+     * ValidPaymentMethod should be configured in organisation and event. And if even already started then event should not have PaymentProxy.OFFLINE as only payment method
+     *
+     * @param paymentMethod
+     * @param event
+     * @param configurationManager
+     * @return
+     */
+    public static boolean isValidPaymentMethod(PaymentManager.PaymentMethod paymentMethod, Event event, ConfigurationManager configurationManager) {
+        return paymentMethod.isActive() && event.getAllowedPaymentProxies().contains(paymentMethod.getPaymentProxy()) && (!paymentMethod.getPaymentProxy().equals(PaymentProxy.OFFLINE) || hasValidOfflinePaymentWaitingPeriod(event, configurationManager));
+    }
+
     private void reTransitionToPending(String reservationId) {
         int updatedReservation = ticketReservationRepository.updateTicketStatus(reservationId, TicketReservationStatus.PENDING.toString());
         Validate.isTrue(updatedReservation == 1, "expected exactly one updated reservation, got "+updatedReservation);

--- a/src/main/resources/alfio/i18n/public.properties
+++ b/src/main/resources/alfio/i18n/public.properties
@@ -307,7 +307,7 @@ show-event.sold-out.message=Subscribe to the waiting queue and we''ll inform you
 show-event.sold-out.subscribe=subscribe
 show-event.sold-out.subscription-complete=Thank you for joining the waiting queue. We''ll keep you posted!
 show-event.sold-out.subscription-error=Something went wrong, please retry in few minutes. Thank you!
-show-event.offline-payment-not-available=We''re sorry, Cannot confirm an offline reservation after event start.
+show-event.offline-payment-not-available=Due to a wrong configuration, it''s not possible to sell tickets right now. Please contact the organizers.
 
 email-waiting-queue.subscribed.subject=You joined the waiting queue for {0}
 email-waiting-queue.subscribed.text=As requested, you joined the waiting queue for the event {0}. We''ll keep you posted if something comes up\!

--- a/src/main/resources/alfio/i18n/public.properties
+++ b/src/main/resources/alfio/i18n/public.properties
@@ -307,6 +307,7 @@ show-event.sold-out.message=Subscribe to the waiting queue and we''ll inform you
 show-event.sold-out.subscribe=subscribe
 show-event.sold-out.subscription-complete=Thank you for joining the waiting queue. We''ll keep you posted!
 show-event.sold-out.subscription-error=Something went wrong, please retry in few minutes. Thank you!
+show-event.offline-payment-not-available=We''re sorry, Cannot confirm an offline reservation after event start.
 
 email-waiting-queue.subscribed.subject=You joined the waiting queue for {0}
 email-waiting-queue.subscribed.text=As requested, you joined the waiting queue for the event {0}. We''ll keep you posted if something comes up\!

--- a/src/main/resources/alfio/i18n/public_de.properties
+++ b/src/main/resources/alfio/i18n/public_de.properties
@@ -271,6 +271,7 @@ show-event.sold-out.message=Registrieren dich auf der Warteliste, sobald ein Pla
 show-event.sold-out.subscribe=abonnieren
 show-event.sold-out.subscription-complete=Vielen Dank f\u00FCr die Teilnahme an unserer Warteliste. Wir halten dich auf dem Laufenden!
 show-event.sold-out.subscription-error=Etwas ist schief gelaufen, bitte versuche es in einigen Minuten erneut. Vielen Dank!
+show-event.offline-payment-not-available=DE-Due to a wrong configuration, it''s not possible to sell tickets right now. Please contact the organizers.
 
 email-waiting-queue.subscribed.subject=Du bist der Warteliste beigetreten {0}
 email-waiting-queue.subscribed.text=Wie gew\u00FCnscht, haben wir dich der Warteliste f\u00FCr die Veranstaltung {0} hinzugef\u00FCgt. \u00DCber Neuigkeiten halten wir dich auf dem Laufenden!

--- a/src/main/resources/alfio/i18n/public_it.properties
+++ b/src/main/resources/alfio/i18n/public_it.properties
@@ -261,6 +261,8 @@ show-event.sold-out.message=Iscriviti alla lista d''attesa e verrai avvisato non
 show-event.sold-out.subscribe=iscriviti
 show-event.sold-out.subscription-complete=Grazie per esserti iscritto alla lista d''attesa. Ti terremo informato\!
 show-event.sold-out.subscription-error=Iscrizione non riuscita. Per favore riprova tra qualche minuto, grazie\!
+show-event.offline-payment-not-available=IT-Due to a wrong configuration, it''s not possible to sell tickets right now. Please contact the organizers.
+
 email-waiting-queue.subscribed.subject=Conferma iscrizione alla lista d''attesa per {0}
 email-waiting-queue.subscribed.admin.text=Qualcuno si \u00E8 aggiunto alla lista d''attesa ({0}) per {1}. Maggiori informazioni nell''admin area
 email-waiting-queue.subscribed.text=Come richiesto, abbiamo aggiunto il tuo nome alla lista d''attesa per {0}. Ti faremo sapere non appena ci saranno novit\u00E0\!

--- a/src/main/resources/alfio/i18n/public_nl.properties
+++ b/src/main/resources/alfio/i18n/public_nl.properties
@@ -275,6 +275,7 @@ show-event.sold-out.message=Abonneer op de wachtrij en wij zullen u een bericht 
 show-event.sold-out.subscribe=Abonneer
 show-event.sold-out.subscription-complete=Dankuwel voor het abonneren op de wachtrij. We houden contact\!
 show-event.sold-out.subscription-error=Er ging iets fout, probeer het opnieuw in een paar minuten.
+show-event.offline-payment-not-available=NL-Due to a wrong configuration, it''s not possible to sell tickets right now. Please contact the organizers.
 
 email-waiting-queue.subscribed.subject=U heeft zich geabonneerd op de wachtrij voor {0}
 email-waiting-queue.subscribed.text=U heeft zich geabonneerd op de wachtrij voor {0}. We houden u op de hoogte\!

--- a/src/main/webapp/WEB-INF/templates/event/reservation-page.ms
+++ b/src/main/webapp/WEB-INF/templates/event/reservation-page.ms
@@ -154,7 +154,7 @@
 
     <h2>{{#i18n}}reservation-page.payment{{/i18n}}</h2>
 
-        {{#event.multiplePaymentMethods}}
+        {{#multiplePaymentMethods}}
             <div class="btn-group j-btn-group" data-toggle="buttons">
                 {{#activePaymentMethods}}
                 <label class="btn btn-default tooltip-handler xs-payment-method" {{#is-payment-method}}[STRIPE,{{.}}]  title="Powered by Stripe"{{/is-payment-method}}>
@@ -166,9 +166,9 @@
                 </label>
                 {{/activePaymentMethods}}
             </div>
-        {{/event.multiplePaymentMethods}}
-        {{^event.multiplePaymentMethods}}
-            {{#event.firstPaymentMethod}}
+        {{/multiplePaymentMethods}}
+        {{^multiplePaymentMethods}}
+            {{#activePaymentMethods}}
                 <h4 class="wMarginTop">
                 {{#is-payment-method}}[STRIPE,{{.}}]<i class="fa fa-credit-card"></i> {{#i18n}}reservation-page.credit-card{{/i18n}}{{/is-payment-method}}
                 {{#is-payment-method}}[PAYPAL,{{.}}]<i class="fa fa-paypal"></i> {{#i18n}}reservation-page.paypal{{/i18n}}{{/is-payment-method}}
@@ -176,16 +176,16 @@
                 {{#is-payment-method}}[OFFLINE,{{.}}]<i class="fa fa-exchange"></i> {{#i18n}}reservation-page.offline{{/i18n}}{{/is-payment-method}}
                 </h4>
                 <input type="hidden" name="paymentMethod" value="{{.}}">
-            {{/event.firstPaymentMethod}}
-        {{/event.multiplePaymentMethods}}
-        {{#event.allowedPaymentProxies}}
+            {{/activePaymentMethods}}
+        {{/multiplePaymentMethods}}
+        {{#activePaymentMethods}}
             <div class="payment-method-detail" id="payment-method-{{.}}">
                 {{#is-payment-method}}[STRIPE,{{.}}]{{> /event/payment/stripe }}{{/is-payment-method}}
                 {{#is-payment-method}}[PAYPAL,{{.}}]{{> /event/payment/paypal }}{{/is-payment-method}}
                 {{#is-payment-method}}[ON_SITE,{{.}}]{{> /event/payment/on-site }}{{/is-payment-method}}
                 {{#is-payment-method}}[OFFLINE,{{.}}]{{> /event/payment/offline }}{{/is-payment-method}}
             </div>
-        {{/event.allowedPaymentProxies}}
+        {{/activePaymentMethods}}
     {{/orderSummary.free}}
 
     <div class="checkbox wMarginTop">

--- a/src/main/webapp/WEB-INF/templates/event/show-event.ms
+++ b/src/main/webapp/WEB-INF/templates/event/show-event.ms
@@ -95,6 +95,12 @@
 {{/displayWaitingQueueForm}}
 
 <form method="post" action="{{request.contextPath}}/event/{{event.shortName}}/reserve-tickets" class="form-horizontal">
+{{^validPaymentMethodAvailable}}
+    <div class="alert alert-warning">
+        <h3>{{#i18n}}show-event.offline-payment-not-available{{/i18n}}</h3>
+    </div>
+{{/validPaymentMethodAvailable}}
+{{#validPaymentMethodAvailable}}
     <ul class="list-group">
     {{#ticketCategories}}
         {{> /event/ticket-category.ms }}
@@ -178,7 +184,7 @@
     </div>
 </div>
 {{/hasAccessPromotions}}
-
+{{/validPaymentMethodAvailable}}
     <hr/>
 
     <input type="hidden" name="{{_csrf.parameterName}}" value="{{_csrf.token}}">

--- a/src/test/java/alfio/manager/TicketReservationManagerTest.java
+++ b/src/test/java/alfio/manager/TicketReservationManagerTest.java
@@ -415,7 +415,7 @@ public class TicketReservationManagerTest {
         assertEquals(true, offlinePaymentDeadline.isAfter(ZonedDateTime.now()));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = TicketReservationManager.OfflinePaymentException.class)
     public void throwExceptionAfterEventStart() {
         initOfflinePaymentTest();
         when(event.getBegin()).thenReturn(ZonedDateTime.now().minusDays(1));


### PR DESCRIPTION
if event began already and has only offline payment method then display warning message at event show-event page and disable forward button to reservation/payment page. 
if even began already and has multiple payment method including offline payment then not show offline payment as option in reservation page